### PR TITLE
Remove --remove-pidfile flag

### DIFF
--- a/jobs/paragon/templates/stop
+++ b/jobs/paragon/templates/stop
@@ -7,7 +7,8 @@ PIDFILE="/var/vcap/sys/run/paragon/web.pid"
 
 /sbin/start-stop-daemon \
   --pidfile "$PIDFILE" \
-  --remove-pidfile \
   --retry TERM/20/QUIT/1/KILL \
   --oknodo \
   --stop
+  
+rm "$PIDFILE"


### PR DESCRIPTION
This flag is only supported in start-stop-daemon >= 1.17.19, and at least in the BOSH stemcells I've seen only 1.17.5 is available.