### PR TITLE
Update documentation, post-start and drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ our recommendations for the individual parts of the lifecycle.
 
 Pre-start scripts are run before BOSH hands off control to Monit, so will not necessarily run every time a job starts
 (e.g. if a VM is rebooted outside of BOSH's control). However, `pre-start` scripts will run at least once for every new
-release version that is deployed, and have _no timeout_ (in contrast to a `start` script). Therefore, `pre-start` scripts
-can best be used for performing lengthy set-up of persistent state that must be done for a new version of a release,
-such as database migrations. However, because the `pre-start` script does not necessarily run in every VM your job
-will run in, do not perform any work in temporary directories such as `/var/vcap/sys/run` (see [VM Configuration
+release version that is deployed, and have _no timeout_ (in contrast to a `start` script). Therefore, `pre-start`
+scripts can best be used for performing lengthy set-up of persistent state that must be done for a new version of a
+release, such as database migrations. However, because the `pre-start` script does not necessarily run in every VM your
+job will run in, do not perform any work in temporary directories such as `/var/vcap/sys/run` (see [VM Configuration
 Locations][vm-config-loc] for the list of temporary directories).
 
 [vm-config-loc]: https://bosh.io/docs/vm-config/
@@ -75,10 +75,10 @@ In general, a `pre-start` script should not be necessary and the start script sh
 
 #### Monit Start
 
-The `start` script has two main responsibilities: writing the process ID (PID) to a `.pid` file and starting the main process.
-All setup required for the process to run (that has not been done in the `pre-start` script) must be done at this time.
-Monit places a short timeout on the `.pid` file being written, so the work done in the `start` script should be focused on
-executing your process and getting it healthy quickly.
+The `start` script has two main responsibilities: writing the process ID (PID) to a `.pid` file and starting the main
+process. All setup required for the process to run (that has not been done in the `pre-start` script) must be done at
+this time. Monit places a short timeout on the `.pid` file being written, so the work done in the `start` script should
+be focused on executing your process and getting it healthy quickly.
 
 **Note**: This script will likely run many times, so ensure that it is idempotent (that it can be run repeatedly without
 causing the system to enter a bad state)
@@ -203,12 +203,12 @@ job becoming listed as unhealthy.
 
 #### Drain ([docs](https://bosh.io/docs/drain/))
 
-Drain scripts are optional hooks into the BOSH job lifecycle that are run before stopping the job via Monit. They
-are typically used for services which must perform some work before being shut down, for example flushing a request
-queue or evacuating containers from a Diego cell. As a rule of thumb, if `monit stop`-ping your job could cause dropped
-connections or a lack of availability, a `drain` script should be used to prevent this. Most commonly, your `drain` script
-will send a request to a drain endpoint on your process and wait for it to return rather than implementing the drain
-behavior itself.
+Drain scripts are optional hooks into the BOSH job lifecycle that are run before stopping the job via Monit. They are
+typically used for services which must perform some work before being shut down, for example flushing a request queue or
+evacuating containers from a Diego cell. As a rule of thumb, if `monit stop`-ping your job could cause dropped
+connections or a lack of availability, a `drain` script should be used to prevent this. Most commonly, your `drain`
+script will send a request to a drain endpoint on your process and wait for it to return rather than implementing the
+drain behavior itself.
 
 A concrete example is the [gorouter][gorouter], which has a configurable `drain_wait` parameter. When non-zero,
 gorouter's drain script will instruct gorouter to report itself as unhealthy to its load-balancer with the intent of
@@ -249,12 +249,12 @@ You can see two examples of such scripts that follow this best practice:
 
 #### Monit Stop
 
-The `stop program` in your job's `monit` file is executed after the `drain` script (if present) has finished running. It can
-also be run directly by an operator if they execute `monit stop <job>` on the machine (though operators should
-always consider running `bosh stop <instance-group>/<index>` instead of using `monit stop` directly). By default, there is a 30 second
-timeout on this script completing. Monit will assume scripts taking longer than this have failed. We do not recommend
-changing this value if you need more time. Instead, you should do all the work necessary in your `drain` script such
-that your service can shutdown quickly (where “quickly” generally means in under 10 seconds).
+The `stop program` in your job's `monit` file is executed after the `drain` script (if present) has finished running. It
+can also be run directly by an operator if they execute `monit stop <job>` on the machine (though operators should
+always consider running `bosh stop <instance-group>/<index>` instead of using `monit stop` directly). By default, there
+is a 30 second timeout on this script completing. Monit will assume scripts taking longer than this have failed. We do
+not recommend changing this value if you need more time. Instead, you should do all the work necessary in your `drain`
+script such that your service can shutdown quickly (where “quickly” generally means in under 10 seconds).
 
 If you're not using `drain`, then we recommend that you send `SIGTERM` to your process, which should cause it to start
 shutting down. If your process shuts down at this point then you're good to go. If for some reason your process locks up
@@ -373,10 +373,10 @@ server: <%= server.to_json %>
 
 ### ERB
 
-Any template in your job can use ERB (even the `monit` files!). While this is extremely powerful it can be very difficult
-to understand and maintain complex templates. Therefore, we advise avoiding any ERB in your control scripts wherever
-possible. The control flow of starting and stopping your program should be deterministic and simple. All ERB should be
-relegated to static configuration files so that properties can be interpolated.
+Any template in your job can use ERB (even the `monit` files!). While this is extremely powerful it can be very
+difficult to understand and maintain complex templates. Therefore, we advise avoiding any ERB in your control scripts
+wherever possible. The control flow of starting and stopping your program should be deterministic and simple. All ERB
+should be relegated to static configuration files so that properties can be interpolated.
 
 ### Encoding
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ the [Environment Variables](https://bosh.io/docs/drain/#environment-variables) s
 documentation.
 
 You can see two examples of such scripts that follow this best practice:
-- For etcd, in [cloudfoundry-incubator/cfcr-etcd-release/jobs/etcd/templates/bin/drain.erb](etcd-drain)
-- For Cassandra, in [orange-cloudfoundry/cassandra-boshrelease/jobs/cassandra/templates/bin/drain](cassandra-drain)
+- For etcd, in [cloudfoundry-incubator/cfcr-etcd-release/jobs/etcd/templates/bin/drain.erb][etcd-drain]
+- For Cassandra, in [orange-cloudfoundry/cassandra-boshrelease/jobs/cassandra/templates/bin/drain][cassandra-drain]
 
 [etcd-drain]: https://github.com/cloudfoundry-incubator/cfcr-etcd-release/blob/master/jobs/etcd/templates/bin/drain.erb
 [cassandra-drain]: https://github.com/orange-cloudfoundry/cassandra-boshrelease/blob/master/jobs/cassandra/templates/bin/drain
@@ -307,7 +307,7 @@ mindful of the operator when making decisions about properties.
 - Include a description for every property whenever it is slightly likely that it would help with understanding. It
   can be easy for an operator to misinterpret a property and use it incorrectly.
 
-Here is an example of properly written description, from the [ATC job of Concourse](atc-spec-example)
+Here is an example of properly written description, from the [ATC job of Concourse][atc-spec-example]
 
 ```yaml
   external_url:
@@ -410,7 +410,7 @@ With YAML config files, we recommend encoding properties with `json`:
 cluster_name: <%= p("cluster_name").to_json %> # <- Please observe that you must not quote the value here
 ```
 
-For complex logic in YAML templates, you can adopt [the full-Ruby option](complex-bosh-property-templating), where you
+For complex logic in YAML templates, you can adopt [the full-Ruby option][complex-bosh-property-templating], where you
 first build a Ruby Hash for your YAML configuration, and then `YAML.dump()` it, which properly performs the expected
 encoding.
 
@@ -423,7 +423,7 @@ Don't hesitate to [contact us][contact-us] and submit advices or best-practice e
 Your templates should be simple enough to not need testing, such as by doing a simple passthrough to property parsing
 in your own code, but you may find yourself with more-complex templating needs, such as when writing a release wrapping
 third-party code. Testing BOSH templates is classically a hard topic, but it has been greatly simplified with a new
-version of the `bosh-template` Gem, and a proper documentation of [unit testing](unit-testing) with it.
+version of the `bosh-template` Gem, and a proper documentation of [unit testing][unit-testing] with it.
 
 As it might still be difficult to test BOSH template rendering, you could also imagine having a simple template (e.g.
 `<% p('my-properties').to_json %>`) that you would transform with a custom executable, which you can test in your
@@ -438,7 +438,7 @@ We advise you to use the `#!/usr/bin/env bash` sheebang variant.
 The [ShellCheck][shellcheck] tool can be used to find common errors in your `bash` scripts. This yet another reason to
 keep ERB out of your scripts!
 
-You can also possibly use [BATS](bats) unit tests, or similar testing frameworks.
+You can also possibly use [BATS][bats] unit tests, or similar testing frameworks.
 
 [shellcheck]: https://github.com/koalaman/shellcheck
 [bats]: https://github.com/sstephenson/bats
@@ -465,7 +465,6 @@ components.
 [addons]: https://bosh.io/docs/runtime-config/#addons
 [google-fluentd]: https://github.com/cloudfoundry-community/stackdriver-tools#deploying-host-logging
 [syslog-release]: https://github.com/cloudfoundry/syslog-release
-[loggregator]: https://github.com/cloudfoundry/loggregator
 
 **Backwards Compatibility Warning**: If your release is currently responsible for forwarding logs off-system, by
 following this guide and removing that functionality, you are putting the onus for logging on deployment authors
@@ -478,7 +477,9 @@ be lost. If you are removing this functionality, please coordinate appropriately
 ### Metron Agent
 
 `metron_agent` has functionality to forward syslogs, but this has been superseded by `syslog-release`. `metron_agent`
-should only be used to forward logs to loggregator.
+should only be used to forward logs to [loggregator][loggregator].
+
+[loggregator]: https://github.com/cloudfoundry/loggregator
 
 ### The Ol' `tee` and `logger` Approach
 

--- a/jobs/paragon/templates/drain
+++ b/jobs/paragon/templates/drain
@@ -1,9 +1,32 @@
 #!/usr/bin/env bash
 
-# If a command fails, exit immediately
-set -e
+# If a command fails, in a pipeline or not, exit immediately
+set -e -o pipefail
 
-# blocks until drained
+function prepend_datetime() {
+  awk -W interactive '{ system("echo -n [$(date +%FT%T%z)]"); print " " $0 }'
+}
+
+# Before redirecting stdout and stderr, copy the file descriptor for original
+# stdout where BOSH is expecting an integer, and only that.
+exec 3>&1
+exec \
+    1> >(prepend_datetime >> /var/vcap/sys/log/paragon/drain.out.log) \
+    2> >(prepend_datetime >> /var/vcap/sys/log/paragon/drain.err.log)
+
+output_for_bosh() {
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        echo "paragon process is properly drained"
+    else
+        echo "drain failed"
+    fi
+
+    echo $exit_code >&3
+}
+
+trap output_for_bosh EXIT
+
+# blocks until drained, with a 10 minutes timeout
 curl -sf --max-time 600 -X POST https://127.0.0.1:6060/admin/drain
-
-echo 0

--- a/jobs/paragon/templates/post-start
+++ b/jobs/paragon/templates/post-start
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 
-# If a command fails, exit immediately
-set -e
+# If a command fails, in a pipeline or not, exit immediately
+set -e -o pipefail
 
-export timeout=120
-export polling_frequency=1
+function prepend_datetime() {
+  awk -W interactive '{ system("echo -n [$(date +%FT%T%z)]"); print " " $0 }'
+}
 
-export max_attempts=$((timeout / polling_frequency))
-export attempts=0
+exec \
+    1> >(prepend_datetime >> /var/vcap/sys/log/paragon/post-start.out.log) \
+    2> >(prepend_datetime >> /var/vcap/sys/log/paragon/post-start.err.log)
+
+timeout=120
+polling_frequency=1
+
+max_attempts=$((timeout / polling_frequency))
+attempts=0
 while [[ "$max_attempts" -ge "$attempts" ]]; do
     set +e
     echo "attempt $attempts"
     curl -f --max-time 120 https://127.0.0.1:58074/healthcheck
     if [[ $? -eq 0 ]]; then
+        echo "post-start succeeded." \
+            "Paragon is healthy after $attempts of $polling_frequency seconds."
         exit 0
     fi
     set -e
@@ -22,4 +32,6 @@ while [[ "$max_attempts" -ge "$attempts" ]]; do
     sleep "$polling_frequency"
 done
 
+echo "post-start failed." \
+    "Paragon is still unhealthy after $timeout attemps of $polling_frequency seconds."
 exit 1


### PR DESCRIPTION
Hi,

I this third PR, I first suggest various levels of improvements to the documentation.
Please review my commits separately to access the different levels of additions:
1. fixes for links to the documentation
2. minor syntax improvements, with no change to the text
3. additions about logging, drain scripts, encoding, and unit testing
4. reformatting with no change to the text

Additionally, I submit here rewrites of `post-start` and `drain` scripts so that they match with the new recommendations of the documentation, and recent update of the BOSH documentation (about 'scale-in' conditions in `drain` scripts) that I submitted after discussing the subject with Dmitriy.

All in all, I'm glad we can maintain here a very good set of best practice for BOSH Release authoring!

Best,